### PR TITLE
Update config.load_defaults from 7.0 to 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module ProjectDaedalus
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,5 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 0) do
 end


### PR DESCRIPTION
Updates `config.load_defaults` from 7.0 to 7.1 to match the actual Rails version in use. Also bumps the schema version.

All 222 specs pass with this change.

Closes #61