### PR TITLE
Remove unused ActiveRecord artifacts

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationRecord < ActiveRecord::Base
-  primary_abstract_class
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 require_relative "support/factory_bot"
 require_relative "support/chrome"
@@ -8,67 +7,18 @@ require_relative "support/chrome"
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 
-# Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "rspec/rails"
-# Add additional requires below this line. Rails is not loaded until this point!
-
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
-
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  abort e.to_s.strip
-end
 
 RSpec.configure do |config|
-  # Set default host for request specs to avoid host authorization errors
   config.before(:each, type: :request) do
     host! "localhost"
   end
 
-  # Not using ActiveRecord fixtures since this project uses Firestore
-  # config.fixture_path = Rails.root.join("/spec/fixtures")
+  # ActiveRecord is not used for data storage (Firestore is the backend)
+  config.use_active_record = false
 
-  # Not using transactional fixtures since this project uses Firestore
-  # config.use_transactional_fixtures = true
-
-  # You can uncomment this line to turn off ActiveRecord support entirely.
-  # config.use_active_record = false
-
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, type: :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-
-  # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
 end


### PR DESCRIPTION
Cleans up unused AR artifacts while keeping AR in the stack (ActiveStorage depends on it).

- Remove `application_record.rb` (never used — models use ActiveModel + Firestore)
- Remove SQLite database files
- Clean up `rails_helper.rb`: remove AR migration checks, set `use_active_record = false`

> Note: Fully removing AR from the Rails stack would also require removing ActiveStorage, which is used for Google Cloud Storage in production. Kept AR as a dependency but explicitly disabled it in tests.

230 specs passing, RuboCop clean.

Closes #65