### PR TITLE
Add manual gem update workflow for GitHub Actions

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -27,7 +27,7 @@ jobs:
           bundler-cache: true
       # Add or replace database setup steps here
       - name: Set up database schema
-        run: bin/rails db:schema:load
+        run: bin/rails db:prepare
       # Add or replace test runners here
       - name: Run tests
         run: bin/rake

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -58,7 +58,7 @@ jobs:
       # Fix #3: Run tests before committing (mirrors CI setup from rubyonrails.yml)
       - name: Set up database schema
         if: steps.audit.outputs.has_updates == 'true'
-        run: bin/rails db:schema:load
+        run: bin/rails db:prepare
         env:
           RAILS_ENV: test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    environment: workflow-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -28,8 +29,11 @@ jobs:
           gem install bundler-audit
           bundle-audit update
 
-          # Capture vulnerable gem names
-          VULNERABLE=$(bundle-audit check 2>&1 | grep "Name:" | awk '{print $2}' | sort -u | tr '\n' ' ')
+          # Capture bundle-audit output without failing the step (non-zero exit = vulns found)
+          AUDIT_OUTPUT=$(bundle-audit check 2>&1 || true)
+
+          # Extract vulnerable gem names
+          VULNERABLE=$(printf '%s\n' "$AUDIT_OUTPUT" | grep "Name:" | awk '{print $2}' | sort -u | tr '\n' ' ')
 
           if [ -z "$VULNERABLE" ]; then
             echo "No vulnerable gems found."
@@ -51,20 +55,26 @@ jobs:
           echo "=== Re-auditing ==="
           bundle-audit check
 
-      # Fix #3: Run tests before committing
-      - name: Run tests to verify nothing is broken
+      # Fix #3: Run tests before committing (mirrors CI setup from rubyonrails.yml)
+      - name: Set up database schema
         if: steps.audit.outputs.has_updates == 'true'
-        run: |
-          bundle install
-          bundle exec rails test
+        run: bin/rails db:schema:load
         env:
           RAILS_ENV: test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+
+      - name: Run tests to verify nothing is broken
+        if: steps.audit.outputs.has_updates == 'true'
+        run: bin/rake
+        env:
+          RAILS_ENV: test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
 
       # Fix #1: Push to a branch and open a PR instead of committing to main
       - name: Create branch and open PR
         if: steps.audit.outputs.has_updates == 'true'
         run: |
-          BRANCH="chore/gem-security-update-$(date +%Y%m%d)"
+          BRANCH="chore/gem-security-update-$(date +%Y%m%d)-${GITHUB_RUN_ID}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -1,0 +1,37 @@
+name: "Update Vulnerable Gems"
+
+on:
+  workflow_dispatch:  # Manual trigger only
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+
+      - name: Update vulnerable gems
+        run: |
+          bundle update
+          echo "=== Key versions after update ==="
+          bundle list | grep -E "rails |activestorage |json |loofah |nokogiri |rack "
+          bundle exec bundle-audit --update || true
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet Gemfile.lock && echo "No changes" && exit 0
+          git add Gemfile.lock
+          git commit -m "Update vulnerable gems via automated workflow
+
+          Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+          git push

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -5,33 +5,89 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
+      # Fix #5: Pin Ruby version to match project's .ruby-version
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '.ruby-version'
           bundler-cache: false
 
-      - name: Update vulnerable gems
+      # Fix #2: Only update gems with known vulnerabilities, not all gems
+      - name: Audit and update only vulnerable gems
+        id: audit
         run: |
-          bundle update
-          echo "=== Key versions after update ==="
-          bundle list | grep -E "rails |activestorage |json |loofah |nokogiri |rack "
-          bundle exec bundle-audit --update || true
+          gem install bundler-audit
+          bundle-audit update
 
-      - name: Commit and push if changed
+          # Capture vulnerable gem names
+          VULNERABLE=$(bundle-audit check 2>&1 | grep "Name:" | awk '{print $2}' | sort -u | tr '\n' ' ')
+
+          if [ -z "$VULNERABLE" ]; then
+            echo "No vulnerable gems found."
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Vulnerable gems found: $VULNERABLE"
+          bundle update $VULNERABLE
+          echo "has_updates=true" >> $GITHUB_OUTPUT
+
+      # Fix #4: Fail if vulnerabilities remain after update
+      - name: Verify vulnerabilities are resolved
+        if: steps.audit.outputs.has_updates == 'true'
         run: |
+          echo "=== Key versions after update ==="
+          bundle list | grep -E "rails |activestorage |json |loofah |nokogiri |rack " || true
+          echo ""
+          echo "=== Re-auditing ==="
+          bundle-audit check
+
+      # Fix #3: Run tests before committing
+      - name: Run tests to verify nothing is broken
+        if: steps.audit.outputs.has_updates == 'true'
+        run: |
+          bundle install
+          bundle exec rails test
+        env:
+          RAILS_ENV: test
+
+      # Fix #1: Push to a branch and open a PR instead of committing to main
+      - name: Create branch and open PR
+        if: steps.audit.outputs.has_updates == 'true'
+        run: |
+          BRANCH="chore/gem-security-update-$(date +%Y%m%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet Gemfile.lock && echo "No changes" && exit 0
+
+          git diff --quiet Gemfile.lock && echo "No changes to Gemfile.lock" && exit 0
+
+          git checkout -b "$BRANCH"
           git add Gemfile.lock
-          git commit -m "Update vulnerable gems via automated workflow
+          git commit -m "Update vulnerable gems via automated audit
 
           Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
-          git push
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "Security: Update vulnerable gems ($(date +%Y-%m-%d))" \
+            --body "## Automated Security Update
+
+          Vulnerable gems were detected by \`bundle-audit\` and updated to patched versions.
+
+          - Tests have passed against the updated Gemfile.lock
+          - Only vulnerable gems were updated (not all dependencies)
+          - Please review the Gemfile.lock diff before merging
+
+          *Created by the Update Vulnerable Gems workflow*" \
+            --base main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '.ruby-version'
-          bundler-cache: false
+          bundler-cache: true
 
       # Fix #2: Only update gems with known vulnerabilities, not all gems
       - name: Audit and update only vulnerable gems
@@ -82,22 +82,30 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add Gemfile.lock
-          git commit -m "Update vulnerable gems via automated audit
 
-          Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+          printf '%s\n' \
+            "Update vulnerable gems via automated audit" \
+            "" \
+            "Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
+            > /tmp/commit-msg.txt
+          git commit -F /tmp/commit-msg.txt
           git push -u origin "$BRANCH"
+
+          printf '%s\n' \
+            "## Automated Security Update" \
+            "" \
+            "Vulnerable gems were detected by \`bundle-audit\` and updated to patched versions." \
+            "" \
+            "- Tests have passed against the updated Gemfile.lock" \
+            "- Only vulnerable gems were updated (not all dependencies)" \
+            "- Please review the Gemfile.lock diff before merging" \
+            "" \
+            "*Created by the Update Vulnerable Gems workflow*" \
+            > /tmp/pr-body.md
 
           gh pr create \
             --title "Security: Update vulnerable gems ($(date +%Y-%m-%d))" \
-            --body "## Automated Security Update
-
-          Vulnerable gems were detected by \`bundle-audit\` and updated to patched versions.
-
-          - Tests have passed against the updated Gemfile.lock
-          - Only vulnerable gems were updated (not all dependencies)
-          - Please review the Gemfile.lock diff before merging
-
-          *Created by the Update Vulnerable Gems workflow*" \
+            --body-file /tmp/pr-body.md \
             --base main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/update-gems.yml` — a manual workflow (`workflow_dispatch`) to run `bundle update` from the Actions UI
- Makes it easy to keep gems up to date with one click instead of running locally

## Test plan
- [ ] Verify workflow appears under Actions tab
- [ ] Test manual trigger runs successfully
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)