### PR TITLE
Update CLAUDE.md for current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Additional Directives
-
-This is a Rails project, read ~/.claude/RUBY.md and ~/.claude/RAILS.md for additional instructions
-
 ## Project Overview
 
-Project Daedalus is a Rails 7.1 application that serves as a website for the Icarus Modding Tools community, featuring mod and tool listings. The application uses Ruby 3.4.8 and Google Cloud Firestore as its data backend.
+Project Daedalus is a Rails 7.2 application that serves as a website for the Icarus Modding Tools community, featuring mod and tool listings. The application uses Ruby 3.4.9 and Google Cloud Firestore as its data backend.
 
 ## Architecture
 
@@ -16,21 +12,28 @@ Project Daedalus is a Rails 7.1 application that serves as a website for the Ica
 
 The application uses **Firestore as its database** instead of Active Record. Two main models (`Mod` and `Tool`) include the `Firestorable` concern to connect to Google Cloud Firestore:
 
-- **Mod**: Represents game modifications with support for multiple file formats (`.pak`, `.zip`, `.exmodz`)
+- **Mod**: Represents game modifications with support for multiple file formats (`.pak`, `.zip`, `.exmodz`, `.exmod`)
 - **Tool**: Represents modding tools and utilities
 
-Both models use `ActiveModel::Model` rather than `ActiveRecord::Base` and include two key concerns:
+Both models use `ActiveModel::Model` rather than `ActiveRecord::Base` and include key concerns:
 
 - `Firestorable`: Provides Firestore connection using credentials from Rails encrypted credentials
 - `Convertable`: Handles URL transformations (e.g., converting GitHub URLs to raw content URLs)
+- `Displayable`: Formatting helpers for display strings (updated_string, version_string, author_slug, readme fetching)
+- `GithubStats` (Mod only): Non-blocking async GitHub API stats with cache-first pattern and sentinel-based dogpile prevention
 
 ### Controllers
 
 Standard Rails controllers handle routing:
-- `ModsController`: Lists and displays mods, supports filtering by author
-- `ToolsController`: Lists tools by author (detail view commented out)
+- `ModsController`: Lists and displays mods, supports filtering by author, prev/next navigation, analytics
+- `ToolsController`: Lists tools by author
 - `HomeController`: Static home page
 - `InfoController`: Static info page
+- `LocalesController`: Handles locale switching via cookie persistence
+
+### i18n
+
+The application uses Rails i18n with all user-visible strings in `config/locales/en.yml`. The locale detection chain is: cookie → Accept-Language header → default (en). To add a new language, drop in a locale YAML file and add the symbol to `config.i18n.available_locales` in `config/application.rb`.
 
 ### Frontend
 
@@ -102,10 +105,14 @@ kamal console          # Open Rails console in production (alias configured)
 
 ## Testing Guidelines
 
-1. Use FactoryBot factories (in `spec/factories/`) for creating test data
-2. Request specs should test HTTP responses and routing
-3. Model specs should test business logic and concern behavior
-4. Since models don't use ActiveRecord, focus on testing the Firestore integration and data transformation methods
+1. Always start with a test for functional code changes
+2. Use FactoryBot factories (in `spec/factories/`) for creating test data
+3. Request specs should test HTTP responses and routing
+4. Model specs should test business logic and concern behavior
+5. Since models don't use ActiveRecord, focus on testing the Firestore integration and data transformation methods
+6. Firestore is unavailable in CI — request specs that hit `root_path` (routes to `mods#index`) will fail. Use `/home` for locale/routing tests instead
+7. Helper specs in `spec/helpers/` for view helper methods (e.g., `ModHelper`, `AnalyticsHelper`)
+8. View specs in `spec/views/` for template rendering
 
 ## Key Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Additional Directives
+
+This is a Rails project, read ~/.claude/RUBY.md and ~/.claude/RAILS.md for additional instructions
+
 ## Project Overview
 
 Project Daedalus is a Rails 7.2 application that serves as a website for the Icarus Modding Tools community, featuring mod and tool listings. The application uses Ruby 3.4.9 and Google Cloud Firestore as its data backend.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a Rails project, read ~/.claude/RUBY.md and ~/.claude/RAILS.md for addit
 
 ## Project Overview
 
-Project Daedalus is a Rails 7.2 application that serves as a website for the Icarus Modding Tools community, featuring mod and tool listings. The application uses Ruby 3.4.9 and Google Cloud Firestore as its data backend.
+Project Daedalus is a Rails 8.0 application that serves as a website for the Icarus Modding Tools community, featuring mod and tool listings. The application uses Ruby 3.4.9 and Google Cloud Firestore as its data backend, with Solid Cache and Solid Queue (SQLite-backed) handling cache and background jobs.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@
 
 Website for the [Daedalus Project](https://projectdaedalus.app); Icarus Modding Tools
 
-- Mod Listings
+Built with Rails 7.2, Ruby 3.4, Tailwind CSS, and Google Cloud Firestore.
+
+- Mod Listings (`.pak`, `.zip`, `.exmodz`, `.exmod` formats)
 - Modding Tool Links
+- i18n-ready (English by default, infrastructure for additional languages)
+- Analytics dashboard for mod authors
+- GitHub repository stats integration
+
+## Development
+
+```bash
+bin/setup    # Initial setup
+bin/dev      # Start dev server with Tailwind watch
+bin/rspec    # Run tests
+bin/audit    # Run security audits (bundle-audit + brakeman + rubocop)
+```
 
 ## License
 
-Webside Code is Copyright 2023 Donovan Young and released under MIT licensing
+Website Code is Copyright 2023-2026 Donovan Young and released under MIT licensing


### PR DESCRIPTION
## Summary

CLAUDE.md was outdated — this brings it in line with the current codebase so Claude Code works properly.

- Rails 7.1 → **7.2**, Ruby 3.4.8 → **3.4.9**
- Removed `~/.claude/RUBY.md` and `~/.claude/RAILS.md` references (local files that don't exist in CI or for contributors)
- Added `.exmod` to supported file formats
- Documented new concerns (`Displayable`, `GithubStats`), `LocalesController`, and i18n infrastructure
- Updated testing guidelines: "always start with a test", Firestore CI limitation, helper/view spec conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>