### PR TITLE
Add JSON API endpoint for Discord mod notifications

### DIFF
--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -42,6 +42,8 @@ module Api
         id: mod.id,
         name: mod.name,
         author: mod.author,
+        author_slug: mod.author_slug,
+        slug: mod.slug,
         version: mod.version,
         compatibility: mod.compatibility,
         description: truncate_text(mod.description, MAX_DESCRIPTION_LENGTH),

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -47,10 +47,22 @@ module Api
         description: truncate_text(mod.description, MAX_DESCRIPTION_LENGTH),
         image_url: mod.image_url,
         file_types: mod.file_types.map(&:to_s),
+        preferred_download: preferred_download(mod),
         created_at: mod.created_at&.iso8601,
         updated_at: mod.updated_at&.iso8601,
         url: mod_url(mod)
       }
+    end
+
+    # Returns the primary download URL and format for the mod, if available.
+    def preferred_download(mod)
+      type = mod.preferred_type
+      return nil unless type
+
+      url = mod.get_url(type)
+      return nil if url.blank?
+
+      { type: type.to_s, url: url }
     end
 
     # Use a fixed host so cached responses always contain the production URL,

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -32,10 +32,10 @@ module Api
       render json: { error: "Service temporarily unavailable" }, status: :service_unavailable
     end
 
-    private
-
     MAX_DESCRIPTION_LENGTH = 500
     SITE_HOST = "projectdaedalus.app"
+
+    private
 
     def serialize_mod(mod)
       {

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -7,6 +7,11 @@ module Api
     # Cache the JSON response to reduce Firestore reads and limit abuse.
     # External consumers should respect Cache-Control / ETag headers.
     CACHE_TTL = 2.minutes
+    # Short TTL on the failure path so a Firestore outage doesn't translate
+    # into a tight retry loop hitting the upstream on every request.
+    ERROR_CACHE_TTL = 30.seconds
+    CACHE_KEY = "api/mods.json"
+    ERROR_CACHE_KEY = "api/mods.json:unavailable"
 
     # GET /api/mods.json
     # Returns a lightweight JSON feed of all mods for external consumers
@@ -16,7 +21,11 @@ module Api
       response.headers["Access-Control-Allow-Methods"] = "GET"
       response.headers["X-Content-Type-Options"] = "nosniff"
 
-      json = Rails.cache.fetch("api/mods.json", expires_in: CACHE_TTL) do
+      if Rails.cache.read(ERROR_CACHE_KEY)
+        return render json: { error: "Service temporarily unavailable" }, status: :service_unavailable
+      end
+
+      json = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) do
         mods = Mod.all
         {
           updated_at: Time.current.iso8601,
@@ -29,6 +38,9 @@ module Api
       render json: json
     rescue StandardError => e
       Rails.logger.error("API mods#index failed: #{e.class} - #{e.message}")
+      # Throttle retries to upstream during an outage by remembering the
+      # failure for a short window.
+      Rails.cache.write(ERROR_CACHE_KEY, true, expires_in: ERROR_CACHE_TTL)
       render json: { error: "Service temporarily unavailable" }, status: :service_unavailable
     end
 

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -27,11 +27,15 @@ module Api
 
       expires_in CACHE_TTL, public: true
       render json: json
+    rescue StandardError => e
+      Rails.logger.error("API mods#index failed: #{e.class} - #{e.message}")
+      render json: { error: "Service temporarily unavailable" }, status: :service_unavailable
     end
 
     private
 
     MAX_DESCRIPTION_LENGTH = 500
+    SITE_HOST = "projectdaedalus.app"
 
     def serialize_mod(mod)
       {
@@ -49,12 +53,14 @@ module Api
       }
     end
 
+    # Use a fixed host so cached responses always contain the production URL,
+    # regardless of which host/proxy the first request came through.
     def mod_url(mod)
       Rails.application.routes.url_helpers.mod_detail_url(
         author: mod.author_slug,
         slug: mod.slug,
-        host: request.host,
-        protocol: request.protocol
+        host: SITE_HOST,
+        protocol: "https"
       )
     end
 

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -4,20 +4,34 @@ module Api
   class ModsController < ApplicationController
     skip_forgery_protection
 
+    # Cache the JSON response to reduce Firestore reads and limit abuse.
+    # External consumers should respect Cache-Control / ETag headers.
+    CACHE_TTL = 2.minutes
+
     # GET /api/mods.json
     # Returns a lightweight JSON feed of all mods for external consumers
     # (e.g. Discord bots, RSS readers, CI pipelines).
     def index
-      mods = Mod.all
+      response.headers["Access-Control-Allow-Origin"] = "*"
+      response.headers["Access-Control-Allow-Methods"] = "GET"
+      response.headers["X-Content-Type-Options"] = "nosniff"
 
-      render json: {
-        updated_at: Time.current.iso8601,
-        count: mods.size,
-        mods: mods.map { |mod| serialize_mod(mod) }
-      }
+      json = Rails.cache.fetch("api/mods.json", expires_in: CACHE_TTL) do
+        mods = Mod.all
+        {
+          updated_at: Time.current.iso8601,
+          count: mods.size,
+          mods: mods.map { |mod| serialize_mod(mod) }
+        }.to_json
+      end
+
+      expires_in CACHE_TTL, public: true
+      render json: json
     end
 
     private
+
+    MAX_DESCRIPTION_LENGTH = 500
 
     def serialize_mod(mod)
       {
@@ -26,13 +40,29 @@ module Api
         author: mod.author,
         version: mod.version,
         compatibility: mod.compatibility,
-        description: mod.description,
+        description: truncate_text(mod.description, MAX_DESCRIPTION_LENGTH),
         image_url: mod.image_url,
         file_types: mod.file_types.map(&:to_s),
         created_at: mod.created_at&.iso8601,
         updated_at: mod.updated_at&.iso8601,
-        url: "https://projectdaedalus.app/mods/#{mod.author_slug}/#{mod.slug}"
+        url: mod_url(mod)
       }
+    end
+
+    def mod_url(mod)
+      Rails.application.routes.url_helpers.mod_detail_url(
+        author: mod.author_slug,
+        slug: mod.slug,
+        host: request.host,
+        protocol: request.protocol
+      )
+    end
+
+    def truncate_text(text, max_length)
+      return "" if text.blank?
+      return text if text.length <= max_length
+
+      "#{text[0, max_length - 1]}…"
     end
   end
 end

--- a/app/controllers/api/mods_controller.rb
+++ b/app/controllers/api/mods_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  class ModsController < ApplicationController
+    skip_forgery_protection
+
+    # GET /api/mods.json
+    # Returns a lightweight JSON feed of all mods for external consumers
+    # (e.g. Discord bots, RSS readers, CI pipelines).
+    def index
+      mods = Mod.all
+
+      render json: {
+        updated_at: Time.current.iso8601,
+        count: mods.size,
+        mods: mods.map { |mod| serialize_mod(mod) }
+      }
+    end
+
+    private
+
+    def serialize_mod(mod)
+      {
+        id: mod.id,
+        name: mod.name,
+        author: mod.author,
+        version: mod.version,
+        compatibility: mod.compatibility,
+        description: mod.description,
+        image_url: mod.image_url,
+        file_types: mod.file_types.map(&:to_s),
+        created_at: mod.created_at&.iso8601,
+        updated_at: mod.updated_at&.iso8601,
+        url: "https://projectdaedalus.app/mods/#{mod.author_slug}/#{mod.slug}"
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@
 Rails.application.routes.draw do
   Healthcheck.routes(self)
 
+  # Lightweight JSON API for external consumers (Discord bots, etc.)
+  namespace :api, defaults: { format: :json } do
+    resources :mods, only: [:index]
+  end
+
   get "home", to: "home#index"
   get "info", to: "info#index"
 

--- a/spec/requests/api_mods_spec.rb
+++ b/spec/requests/api_mods_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API Mods" do
+  let(:mods) { build_list(:mod, 3) }
+
+  before do
+    allow(Mod).to receive(:all).and_return(mods)
+  end
+
+  describe "GET /api/mods" do
+    it "returns http success" do
+      get "/api/mods"
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns JSON content type" do
+      get "/api/mods"
+
+      expect(response.content_type).to include("application/json")
+    end
+
+    it "returns the correct mod count" do
+      get "/api/mods"
+
+      json = JSON.parse(response.body)
+      expect(json["count"]).to eq(3)
+      expect(json["mods"].size).to eq(3)
+    end
+
+    it "includes required fields for each mod" do
+      get "/api/mods"
+
+      json = JSON.parse(response.body)
+      mod_json = json["mods"].first
+
+      %w[id name author author_slug slug version description file_types url created_at updated_at].each do |field|
+        expect(mod_json).to have_key(field), "missing field: #{field}"
+      end
+    end
+
+    it "includes updated_at timestamp in response root" do
+      get "/api/mods"
+
+      json = JSON.parse(response.body)
+      expect(json).to have_key("updated_at")
+    end
+
+    it "sets CORS headers" do
+      get "/api/mods"
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+      expect(response.headers["Access-Control-Allow-Methods"]).to eq("GET")
+    end
+
+    it "sets cache headers" do
+      get "/api/mods"
+
+      expect(response.headers["Cache-Control"]).to include("public")
+    end
+
+    it "truncates long descriptions" do
+      long_desc_mod = build(:mod, description: "A" * 1000)
+      allow(Mod).to receive(:all).and_return([long_desc_mod])
+
+      get "/api/mods"
+
+      json = JSON.parse(response.body)
+      expect(json["mods"].first["description"].length).to be <= 500
+    end
+
+    it "returns 503 when Firestore is unavailable" do
+      allow(Mod).to receive(:all).and_raise(StandardError, "Firestore connection failed")
+      Rails.cache.delete("api/mods.json")
+
+      get "/api/mods"
+
+      expect(response).to have_http_status(:service_unavailable)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("Service temporarily unavailable")
+    end
+  end
+end

--- a/spec/requests/api_mods_spec.rb
+++ b/spec/requests/api_mods_spec.rb
@@ -83,27 +83,28 @@ RSpec.describe "API Mods" do
       expect(json["error"]).to eq("Service temporarily unavailable")
     end
 
-    it "short-circuits to 503 while a recent failure is cached" do
-      original = Rails.cache
-      Rails.cache = ActiveSupport::Cache::MemoryStore.new
-
-      call_count = 0
-      allow(Mod).to receive(:all) do
-        call_count += 1
-        raise StandardError, "Firestore connection failed"
+    context "when a recent failure has been cached" do
+      around do |example|
+        original = Rails.cache
+        Rails.cache = ActiveSupport::Cache::MemoryStore.new
+        example.run
+      ensure
+        Rails.cache = original
       end
 
-      get "/api/mods"
-      expect(response).to have_http_status(:service_unavailable)
-      expect(call_count).to eq(1)
+      it "short-circuits to 503 without re-invoking the upstream" do
+        call_count = 0
+        allow(Mod).to receive(:all) do
+          call_count += 1
+          raise StandardError, "Firestore connection failed"
+        end
 
-      # Subsequent request should be served from the failure sentinel
-      # without re-invoking Mod.all.
-      get "/api/mods"
-      expect(response).to have_http_status(:service_unavailable)
-      expect(call_count).to eq(1)
-    ensure
-      Rails.cache = original
+        get "/api/mods"
+        get "/api/mods"
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(call_count).to eq(1)
+      end
     end
   end
 end

--- a/spec/requests/api_mods_spec.rb
+++ b/spec/requests/api_mods_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "API Mods" do
     it "returns the correct mod count" do
       get "/api/mods"
 
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["count"]).to eq(3)
       expect(json["mods"].size).to eq(3)
     end
@@ -33,7 +33,7 @@ RSpec.describe "API Mods" do
     it "includes required fields for each mod" do
       get "/api/mods"
 
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       mod_json = json["mods"].first
 
       %w[id name author author_slug slug version description file_types url created_at updated_at].each do |field|
@@ -44,7 +44,7 @@ RSpec.describe "API Mods" do
     it "includes updated_at timestamp in response root" do
       get "/api/mods"
 
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json).to have_key("updated_at")
     end
 
@@ -67,7 +67,7 @@ RSpec.describe "API Mods" do
 
       get "/api/mods"
 
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["mods"].first["description"].length).to be <= 500
     end
 
@@ -78,7 +78,7 @@ RSpec.describe "API Mods" do
       get "/api/mods"
 
       expect(response).to have_http_status(:service_unavailable)
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["error"]).to eq("Service temporarily unavailable")
     end
   end

--- a/spec/requests/api_mods_spec.rb
+++ b/spec/requests/api_mods_spec.rb
@@ -74,12 +74,36 @@ RSpec.describe "API Mods" do
     it "returns 503 when Firestore is unavailable" do
       allow(Mod).to receive(:all).and_raise(StandardError, "Firestore connection failed")
       Rails.cache.delete("api/mods.json")
+      Rails.cache.delete("api/mods.json:unavailable")
 
       get "/api/mods"
 
       expect(response).to have_http_status(:service_unavailable)
       json = response.parsed_body
       expect(json["error"]).to eq("Service temporarily unavailable")
+    end
+
+    it "short-circuits to 503 while a recent failure is cached" do
+      original = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+      call_count = 0
+      allow(Mod).to receive(:all) do
+        call_count += 1
+        raise StandardError, "Firestore connection failed"
+      end
+
+      get "/api/mods"
+      expect(response).to have_http_status(:service_unavailable)
+      expect(call_count).to eq(1)
+
+      # Subsequent request should be served from the failure sentinel
+      # without re-invoking Mod.all.
+      get "/api/mods"
+      expect(response).to have_http_status(:service_unavailable)
+      expect(call_count).to eq(1)
+    ensure
+      Rails.cache = original
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `/api/mods.json` endpoint that returns all mods as lightweight JSON (name, author, version, timestamps, file types, URLs)
- Designed for external consumers — specifically a Red-DiscordBot cog that polls for new/updated mods and posts rich embeds to a Discord channel
- No authentication required (read-only, same data as the public mods page)

## How it works
The API returns a JSON payload like:
```json
{
  "updated_at": "2026-04-06T12:00:00Z",
  "count": 42,
  "mods": [
    {
      "id": "...",
      "name": "Mod Name",
      "author": "Author",
      "version": "1.0.0",
      "compatibility": "Week 130",
      "description": "...",
      "file_types": ["pak", "exmodz"],
      "created_at": "...",
      "updated_at": "...",
      "url": "https://projectdaedalus.app/mods/author/mod-name"
    }
  ]
}
```

A companion Red-DiscordBot cog (`daedalus_cog`) is provided separately to consume this endpoint.

## Test plan
- [ ] Visit `/api/mods.json` locally and verify JSON output
- [ ] Confirm existing HTML routes still work unchanged
- [ ] Test with the Red cog once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)