### PR TITLE
Fix mods page button colors and table container styling

### DIFF
--- a/app/views/mods/_mod.html.erb
+++ b/app/views/mods/_mod.html.erb
@@ -1,4 +1,4 @@
-<tr id="<%= dom_id mod %>" class="cursor-pointer row-lift border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/70"
+<tr id="<%= dom_id mod %>" class="cursor-pointer row-lift border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800/70"
     data-action="click->mods#navigateTo"
     data-mods-path-param="<%= mod_detail_path(author: mod.author_slug, slug: mod.slug) %>">
   <td class="p-2 sm:p-3 font-medium text-slate-800 dark:text-slate-200"><%= mod.name %></td>
@@ -9,7 +9,7 @@
         data-mods-url-param="<%= raw_url(mod.get_url(type)) %>"
         data-mods-file-name-param="<%= mod.get_name(type) %>"
         type="button"
-        class="z-10 inline-flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs font-medium text-white rounded-md shadow-sm bg-icarus-500 hover:bg-icarus-600 focus:outline-none focus:ring-2 focus:ring-icarus-400 focus:ring-offset-2">
+        class="z-10 inline-flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs font-medium text-white rounded-md shadow-sm bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900">
         <span class="hidden sm:inline">Download </span><%= type.to_s.upcase %>
       </button>
     <% end %>

--- a/app/views/mods/_mod.html.erb
+++ b/app/views/mods/_mod.html.erb
@@ -9,7 +9,7 @@
         data-mods-url-param="<%= raw_url(mod.get_url(type)) %>"
         data-mods-file-name-param="<%= mod.get_name(type) %>"
         type="button"
-        class="z-10 inline-flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs font-medium text-white rounded-md shadow-sm bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900">
+        class="z-10 inline-flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs font-medium text-icarus-900 rounded-md shadow-sm bg-icarus-500 hover:bg-icarus-400 focus:outline-none focus:ring-2 focus:ring-icarus-400 focus:ring-offset-2 dark:focus:ring-offset-slate-900">
         <span class="hidden sm:inline">Download </span><%= type.to_s.upcase %>
       </button>
     <% end %>

--- a/app/views/mods/_mods.html.erb
+++ b/app/views/mods/_mods.html.erb
@@ -3,7 +3,7 @@
     <div class="flex justify-end flex-1">
       <div class="mr-4 text-sm text-icarus-600 dark:text-icarus-500"><%= @total_mods %> mods<%= " (page #{@pagination.current_page} of #{@pagination.total_pages})" if @pagination&.paginated? %></div>
     </div>
-    <div class="overflow-hidden border rounded-xl border-slate-200 dark:border-slate-700 mt-2">
+    <div class="overflow-hidden border rounded-xl border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 mt-2">
       <table class="w-full border-collapse table-auto">
         <thead>
           <tr class="bg-slate-100 dark:bg-slate-800">

--- a/app/views/mods/index.html.erb
+++ b/app/views/mods/index.html.erb
@@ -8,7 +8,7 @@
   .dark .row-lift:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
 </style>
 
-<div data-controller="mods" class="max-w-screen-2xl mx-auto px-4 py-6 md:py-10">
+<div data-controller="mods" class="max-w-screen-2xl mx-auto px-3 py-4 md:px-6 md:py-8">
   <%# Page Header %>
   <div class="mb-6 text-center">
     <h1 class="mb-3 text-3xl font-extrabold tracking-tight md:text-4xl lg:text-5xl text-icarus-500">


### PR DESCRIPTION
## Summary
- Download buttons keep their gold `bg-icarus-500` but switch from `text-white` to `text-icarus-900` (dark brown) for readable contrast
- Table container and rows given explicit `bg-white dark:bg-slate-900` backgrounds so the layout gradient no longer bleeds through unevenly
- Content padding tightened (`px-3 py-4 md:px-6 md:py-8`) so the backing hugs the table more cleanly
- Added `dark:focus:ring-offset-slate-900` to download buttons for correct focus ring in dark mode

## Test plan
- [ ] Verify download button text is readable (dark text on gold) in light & dark mode
- [ ] Verify table rows have a clean white/dark background with no gradient bleeding through
- [ ] Verify the outer container backing sits tighter around the table content
- [ ] Click a download button and confirm the focus ring looks correct in both themes
- [ ] Check responsive layout on mobile still looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)