### PR TITLE
Add Nexus Mods API integration to surface community mods on the index

### DIFF
--- a/app/controllers/mods_controller.rb
+++ b/app/controllers/mods_controller.rb
@@ -90,7 +90,16 @@ class ModsController < ApplicationController
   end
 
   def mods
-    @mods ||= Mod.all
+    @mods ||= combined_mods
+  end
+
+  # Merges curated mods (Firestore `mods`) with mods synced from the
+  # Nexus API (Firestore `nexus_mods`). Curated mods take precedence
+  # when a name+author match exists.
+  def combined_mods
+    (Mod.all + NexusMod.all)
+      .uniq { |mod| [mod.name.to_s.downcase, mod.author_slug] }
+      .sort_by { |mod| mod.name.to_s }
   end
 
   def set_session

--- a/app/models/mod.rb
+++ b/app/models/mod.rb
@@ -104,6 +104,12 @@ class Mod
     name.parameterize
   end
 
+  # Always false on curated mods; NexusMod overrides this to true.
+  # Used by the _mod partial to differentiate render styles.
+  def nexus_source?
+    false
+  end
+
   private
 
   def filename(url)

--- a/app/models/nexus_mod.rb
+++ b/app/models/nexus_mod.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Represents a mod synced from the Nexus Mods API into the `nexus_mods`
+# Firestore collection.
+#
+# Exposes the same public interface as Mod where it overlaps, so the
+# existing _mod.html.erb partial can render either type. The differences:
+#
+#   - preferred_type returns :nexus (no direct download link)
+#   - get_url(:nexus) returns the Nexus mod page URL
+#   - nexus_source? returns true (Mod returns false)
+class NexusMod
+  include ActiveModel::Model
+  include Displayable
+  include Firestorable
+
+  COLLECTION = "nexus_mods"
+
+  ATTRIBUTES = %i[author description downloads endorsements id image_url mod_page_url
+                  name nexus_id summary updated_time uploaded_time version
+                  created_at updated_at].freeze
+
+  ATTRIBUTES.each { |attr| attr_accessor attr }
+
+  def self.all
+    Rails.cache.fetch("firestore/nexus_mods", expires_in: 5.minutes) do
+      fetch_all
+    end
+  end
+
+  def self.fetch_all # :nodoc:
+    mods = firestore.col(COLLECTION).get.filter_map { |doc| from_doc(doc) }
+    mods.sort_by { |m| m.name.to_s }
+  end
+  private_class_method :fetch_all
+
+  def self.from_doc(doc) # :nodoc:
+    data = doc.data
+    new(
+      author: data[:author],
+      description: data[:description].presence || data[:summary].presence || "",
+      downloads: data[:downloads],
+      endorsements: data[:endorsements],
+      id: doc.document_id,
+      image_url: data[:image_url],
+      mod_page_url: data[:mod_page_url],
+      name: data[:name],
+      nexus_id: data[:nexus_id],
+      summary: data[:summary],
+      updated_time: data[:updated_time],
+      uploaded_time: data[:uploaded_time],
+      version: data[:version],
+      created_at: doc.create_time,
+      updated_at: doc.update_time
+    )
+  end
+  private_class_method :from_doc
+
+  def self.expire_cache
+    Rails.cache.delete("firestore/nexus_mods")
+  end
+
+  # --- Mod-compatible interface for the _mod.html.erb partial ---
+
+  def preferred_type
+    :nexus
+  end
+
+  def get_url(_type)
+    mod_page_url
+  end
+
+  def get_name(_type)
+    name
+  end
+
+  def nexus_source?
+    true
+  end
+
+  # Render through the existing mods/_mod partial. Without this, Rails
+  # collection rendering would look for nexus_mods/_nexus_mod and crash.
+  def to_partial_path
+    "mods/mod"
+  end
+
+  def slug
+    name.to_s.parameterize
+  end
+
+  # Nexus API doesn't expose Icarus week-compatibility metadata.
+  def compatibility
+    nil
+  end
+
+  # Nexus mods have summaries and descriptions in the API response;
+  # we don't fetch a separate README.
+  def readme
+    nil
+  end
+end

--- a/app/services/nexus_client.rb
+++ b/app/services/nexus_client.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+# Thin wrapper around the Nexus Mods public API.
+# Docs: https://app.swaggerhub.com/apis-docs/NexusMods/nexus-mods_public_api_params_in_form_data
+#
+# Requires Rails.application.credentials.nexus_api_key (or NEXUS_API_KEY env var)
+# to be set. A key can be generated from:
+#   https://www.nexusmods.com/users/myaccount?tab=api+access
+class NexusClient
+  HOST = "api.nexusmods.com"
+  GAME = "icarus"
+  TIMEOUT = 10
+
+  class Error < StandardError; end
+  class NotFound < Error; end
+  class RateLimited < Error; end
+  class Unauthorized < Error; end
+
+  def initialize(api_key: nil)
+    @api_key = api_key || resolve_api_key
+    raise Error, "Nexus API key is missing" if @api_key.blank?
+  end
+
+  # Latest 10 mods added for the game.
+  def latest_added
+    get("/v1/games/#{GAME}/mods/latest_added.json")
+  end
+
+  # Latest 10 mods updated for the game.
+  def latest_updated
+    get("/v1/games/#{GAME}/mods/latest_updated.json")
+  end
+
+  # Top 10 trending mods for the game.
+  def trending
+    get("/v1/games/#{GAME}/mods/trending.json")
+  end
+
+  # Full details for a specific mod.
+  # Raises NotFound if the mod doesn't exist or has been hidden.
+  def mod(mod_id)
+    get("/v1/games/#{GAME}/mods/#{mod_id}.json")
+  end
+
+  private
+
+  def resolve_api_key
+    creds = Rails.application.credentials
+    from_creds = creds.respond_to?(:nexus_api_key) ? creds.nexus_api_key : nil
+    from_creds.presence || ENV.fetch("NEXUS_API_KEY", nil)
+  end
+
+  def get(path)
+    uri = URI::HTTPS.build(host: HOST, path: path)
+    req = Net::HTTP::Get.new(uri)
+    req["apikey"] = @api_key
+    req["Accept"] = "application/json"
+    req["Application-Name"] = "ProjectDaedalus"
+    req["Application-Version"] = "1.0"
+
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
+      http.request(req)
+    end
+
+    case res
+    when Net::HTTPSuccess then JSON.parse(res.body)
+    when Net::HTTPNotFound then raise NotFound, "Nexus mod not found at #{path}"
+    when Net::HTTPTooManyRequests then raise RateLimited, "Nexus API rate limit hit (429)"
+    when Net::HTTPUnauthorized, Net::HTTPForbidden then raise Unauthorized, "Nexus API auth failed (#{res.code})"
+    else raise Error, "Nexus API #{res.code}: #{res.body}"
+    end
+  end
+end

--- a/app/services/nexus_sync.rb
+++ b/app/services/nexus_sync.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Pulls mod metadata from the Nexus Mods API and upserts each mod
+# into the `nexus_mods` Firestore collection.
+#
+# Three modes:
+#   - sync (steady state): fetches latest_added / latest_updated / trending
+#     and refetches each returned mod for fresh details. ~33 requests/run.
+#
+#   - bootstrap(range): walks a contiguous range of Nexus mod IDs.
+#     Used once to seed the collection, since the Nexus API has no
+#     "list all mods" endpoint.
+#
+#   - refresh_all: refetches every mod ID currently in Firestore.
+#     One API call per mod — call sparingly (e.g. weekly).
+#
+# Rate limit notes:
+#   Nexus free tier allows 2,500 requests/day, 5,000/hour. The default
+#   `sync` mode comfortably fits with multiple runs per day.
+class NexusSync
+  COLLECTION = "nexus_mods"
+
+  def initialize(client: NexusClient.new, logger: Rails.logger)
+    @client = client
+    @logger = logger
+  end
+
+  # Steady-state sync. Cheap (~33 API calls) and safe to run every few hours.
+  def sync
+    ids = discover_active_ids
+    @logger.info("[NexusSync] sync: refreshing #{ids.size} active mod(s)")
+
+    upsert_each(ids)
+  end
+
+  # Walk a range of mod IDs sequentially. Used for initial seeding.
+  # Sleeps briefly between requests to be polite to the API.
+  def bootstrap(range)
+    @logger.info("[NexusSync] bootstrap: walking IDs #{range.first}..#{range.last}")
+
+    upserted = 0
+    range.each do |id|
+      data = safe_fetch(id)
+      next unless data
+
+      upsert(data)
+      upserted += 1
+      sleep 0.5
+    end
+    upserted
+  end
+
+  # Refetch every mod we already know about. Use sparingly.
+  def refresh_all
+    ids = NexusMod.firestore.col(COLLECTION).get.map { |doc| doc.document_id.to_i }
+    @logger.info("[NexusSync] refresh_all: refreshing #{ids.size} known mod(s)")
+
+    upsert_each(ids)
+  end
+
+  private
+
+  def discover_active_ids
+    [@client.latest_added, @client.latest_updated, @client.trending]
+      .flatten
+      .filter_map { |m| m["mod_id"] }
+      .uniq
+  rescue NexusClient::Error => e
+    @logger.warn("[NexusSync] discovery failed: #{e.message}")
+    []
+  end
+
+  def upsert_each(ids)
+    upserted = 0
+    ids.each do |id|
+      data = safe_fetch(id)
+      next unless data
+
+      upsert(data)
+      upserted += 1
+    end
+    upserted
+  end
+
+  def safe_fetch(id)
+    @client.mod(id)
+  rescue NexusClient::NotFound
+    nil
+  rescue NexusClient::Error => e
+    @logger.warn("[NexusSync] mod #{id} fetch failed: #{e.message}")
+    nil
+  end
+
+  def upsert(data)
+    return unless data["available"]
+
+    NexusMod.firestore.col(COLLECTION).doc(data["mod_id"].to_s).set(
+      nexus_id: data["mod_id"],
+      name: data["name"],
+      author: data["author"].presence || data["uploaded_by"],
+      summary: data["summary"],
+      description: data["description"],
+      version: data["version"],
+      image_url: data["picture_url"],
+      mod_page_url: "https://www.nexusmods.com/icarus/mods/#{data["mod_id"]}",
+      endorsements: data["endorsement_count"],
+      downloads: data["mod_downloads"],
+      uploaded_time: data["uploaded_time"],
+      updated_time: data["updated_time"],
+      synced_at: Time.now.utc
+    )
+  end
+end

--- a/app/views/mods/_mod.html.erb
+++ b/app/views/mods/_mod.html.erb
@@ -1,9 +1,21 @@
-<tr id="<%= dom_id mod %>" class="cursor-pointer row-lift border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/70"
+<tr id="<%= dom_id mod %>" class="row-lift border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/70 <%= 'cursor-pointer' unless mod.nexus_source? %>"
+    <% unless mod.nexus_source? %>
     data-action="click->mods#navigateTo"
-    data-mods-path-param="<%= mod_detail_path(author: mod.author_slug, slug: mod.slug) %>">
-  <td class="p-2 sm:p-3 font-medium text-slate-800 dark:text-slate-200"><%= mod.name %></td>
+    data-mods-path-param="<%= mod_detail_path(author: mod.author_slug, slug: mod.slug) %>"
+    <% end %>>
+  <td class="p-2 sm:p-3 font-medium text-slate-800 dark:text-slate-200">
+    <%= mod.name %>
+    <% if mod.nexus_source? %>
+      <span class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-icarus-500/10 text-icarus-500 align-middle" title="Synced from Nexus Mods">NEXUS</span>
+    <% end %>
+  </td>
   <td class="p-2 sm:p-3 whitespace-nowrap">
-    <% if type = mod.preferred_type %>
+    <% if mod.nexus_source? %>
+      <a href="<%= mod.mod_page_url %>" target="_blank" rel="noopener noreferrer"
+         class="z-10 inline-flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs font-medium text-white rounded-md shadow-sm bg-icarus-500 hover:bg-icarus-600 focus:outline-none focus:ring-2 focus:ring-icarus-400 focus:ring-offset-2">
+        <span class="hidden sm:inline">View on </span>Nexus &nearr;
+      </a>
+    <% elsif type = mod.preferred_type %>
       <button
         data-action="mods#download"
         data-mods-url-param="<%= raw_url(mod.get_url(type)) %>"

--- a/lib/tasks/nexus.rake
+++ b/lib/tasks/nexus.rake
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+namespace :nexus do # rubocop:disable Metrics/BlockLength
+  desc <<~DESC
+    Sync Icarus mods from the Nexus Mods API to the `nexus_mods` Firestore
+    collection. Discovers recently-added/updated/trending mods (~33 API calls).
+    Safe to run on a frequent cron schedule.
+
+    Crontab example (every 4 hours, runs from Donovan's machine):
+      0 */4 * * * cd /path/to/project_daedalus && /path/to/bundle exec rake nexus:sync >> log/nexus.log 2>&1
+  DESC
+  task sync: :environment do
+    count = NexusSync.new.sync
+    puts "Nexus sync complete: #{count} mod(s) upserted"
+  end
+
+  desc <<~DESC
+    Bootstrap the `nexus_mods` collection by walking a contiguous range of
+    Nexus mod IDs. Use this once to seed the collection — the Nexus API has
+    no "list all mods" endpoint, so initial population requires sequential
+    enumeration. Sleeps 0.5s between requests.
+
+    Usage:
+      RANGE=1..1000 bin/rails nexus:bootstrap
+  DESC
+  task bootstrap: :environment do
+    raise "Set RANGE=first..last (e.g. RANGE=1..1000)" if ENV["RANGE"].blank?
+
+    first, last = ENV["RANGE"].split("..").map(&:to_i)
+    raise "Invalid RANGE format. Expected 'first..last'." unless first && last && first <= last
+
+    count = NexusSync.new.bootstrap(first..last)
+    puts "Nexus bootstrap complete: #{count} mod(s) upserted from range #{first}..#{last}"
+  end
+
+  desc <<~DESC
+    Refresh every Nexus mod currently stored in Firestore. Uses one API call
+    per mod, so runs against the daily rate limit. Recommended cadence:
+    weekly or less. Mostly useful for refreshing endorsement counts and
+    download stats, which the cheap `sync` task only touches when a mod
+    appears in latest_updated/trending.
+  DESC
+  task refresh_all: :environment do
+    count = NexusSync.new.refresh_all
+    puts "Nexus refresh_all complete: #{count} mod(s) upserted"
+  end
+end

--- a/spec/models/nexus_mod_spec.rb
+++ b/spec/models/nexus_mod_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NexusMod do
+  let(:firestore_client) { instance_double(Google::Cloud::Firestore::Client) }
+  let(:firestore_collection) { instance_double(Google::Cloud::Firestore::CollectionReference) }
+
+  def nexus_doc(mod_id: 12_345, name: "Better Building", author: "ModAuthor")
+    instance_double(Google::Cloud::Firestore::DocumentSnapshot,
+                    document_id: mod_id.to_s,
+                    create_time: Time.now.utc,
+                    update_time: Time.now.utc,
+                    data: {
+                      nexus_id: mod_id,
+                      name: name,
+                      author: author,
+                      description: "A description",
+                      summary: "Short summary",
+                      version: "1.2.3",
+                      image_url: "https://example.com/image.png",
+                      mod_page_url: "https://www.nexusmods.com/icarus/mods/#{mod_id}",
+                      endorsements: 42,
+                      downloads: 1000
+                    })
+  end
+
+  before do
+    # Override the global stub from spec/support/firestore.rb so this spec
+    # exercises the real .all -> fetch_all path.
+    allow(described_class).to receive(:all).and_call_original
+
+    allow(Google::Cloud::Firestore).to receive(:new).and_return(firestore_client)
+    allow(firestore_collection).to receive(:get).and_return([nexus_doc])
+    allow(firestore_client).to receive(:col).with("nexus_mods").and_return(firestore_collection)
+    Rails.cache.delete("firestore/nexus_mods")
+  end
+
+  described_class::ATTRIBUTES.each do |attr|
+    it { is_expected.to respond_to(attr) }
+  end
+
+  describe "::COLLECTION" do
+    it "points at the nexus_mods Firestore collection" do
+      expect(described_class::COLLECTION).to eq("nexus_mods")
+    end
+  end
+
+  describe ".all" do
+    it "returns instances of NexusMod" do
+      expect(described_class.all).to all(be_a(described_class))
+    end
+
+    it "loads documents from the nexus_mods collection" do
+      described_class.all
+      expect(firestore_client).to have_received(:col).with("nexus_mods")
+    end
+
+    it "uses the document_id as the model id" do
+      expect(described_class.all.first.id).to eq("12345")
+    end
+  end
+
+  describe "Mod-compatible interface" do
+    let(:mod) { described_class.all.first }
+
+    it "reports as a nexus source" do
+      expect(mod.nexus_source?).to be(true)
+    end
+
+    it "has a preferred_type of :nexus" do
+      expect(mod.preferred_type).to eq(:nexus)
+    end
+
+    it "returns the Nexus page URL for any get_url call" do
+      expect(mod.get_url(:anything)).to eq("https://www.nexusmods.com/icarus/mods/12345")
+    end
+
+    it "slugifies the name" do
+      expect(mod.slug).to eq("better-building")
+    end
+
+    it "returns nil compatibility (not exposed by the Nexus API)" do
+      expect(mod.compatibility).to be_nil
+    end
+  end
+end

--- a/spec/support/firestore.rb
+++ b/spec/support/firestore.rb
@@ -16,11 +16,19 @@ RSpec.configure do |config|
     end
   end
 
+  # Default stub: NexusMod.all returns [] so controller specs that only
+  # set up Firestore mocks for Mod can continue to work without knowing
+  # about Nexus integration. Specs that exercise NexusMod itself should
+  # override with `allow(NexusMod).to receive(:all).and_call_original`.
+  config.before do
+    allow(NexusMod).to receive(:all).and_return([]) if defined?(NexusMod)
+  end
+
   # Reset memoized Firestore clients after each test to prevent
   # RSpec test doubles from leaking across examples via the
   # class-level @firestore ||= memoization in Firestorable.
   config.after do
-    [Mod, Tool].each do |klass|
+    [Mod, Tool, NexusMod].each do |klass|
       klass.instance_variable_set(:@firestore, nil) if klass.instance_variable_defined?(:@firestore)
     end
     if defined?(SiteContent) && SiteContent.respond_to?(:instance_variable_set) &&


### PR DESCRIPTION
## Summary

Pulls Icarus mods from the [Nexus Mods public API](https://app.swaggerhub.com/apis-docs/NexusMods/nexus-mods_public_api_params_in_form_data) into a new `nexus_mods` Firestore collection and merges them into the existing mods index page. Curated mods (Firestore `mods`) take precedence when a name+author match exists.

Nexus rows are visually distinguished by a `NEXUS` badge and a "View on Nexus ↗" link instead of a download button — the Nexus API doesn't expose direct download URLs for free-tier API clients.

> Replaces #118 (closed) — same content, redone with a clean commit message and a GitHub-verified signature.

## Architecture

**New files**

- `app/services/nexus_client.rb` — thin wrapper around `api.nexusmods.com`. Reads the API key from Rails credentials (`nexus_api_key`) with `NEXUS_API_KEY` env-var fallback for cron environments.
- `app/services/nexus_sync.rb` — three sync modes (sync / bootstrap / refresh_all), all logic centralised here so it can be invoked from a rake task today and a job class later.
- `app/models/nexus_mod.rb` — Firestore-backed model with the same public interface as `Mod` so the existing `_mod.html.erb` partial renders both types. `to_partial_path` is overridden to point at `mods/mod`.
- `lib/tasks/nexus.rake` — three rake tasks intended to be run from a maintainer's machine.
- `spec/models/nexus_mod_spec.rb` — mirrors the `Mod` spec patterns.

**Modified**

- `app/controllers/mods_controller.rb` — `mods` now merges `Mod.all + NexusMod.all` with name+author dedup.
- `app/models/mod.rb` — adds `nexus_source?` returning false.
- `app/views/mods/_mod.html.erb` — Nexus rows render with a "View on Nexus" link and a NEXUS badge; row click is disabled for Nexus rows.
- `spec/support/firestore.rb` — resets `NexusMod`'s memoized Firestore client between tests.

## Rate-limit-aware sync design

Nexus free tier: 2,500 requests/day, 5,000/hour.

- `nexus:sync` (steady state): hits `latest_added` / `latest_updated` / `trending` and fetches each returned mod (~33 API calls per run). Comfortably fits a 4-hour cron.
- `nexus:bootstrap RANGE=1..N`: walks a range of mod IDs sequentially to seed the collection, with a 0.5s pause between requests. Needed once because the Nexus API has no "list all mods" endpoint.
- `nexus:refresh_all`: refetches every known mod (one API call per mod). Recommended weekly or less.

## Setup required after merge

1. Generate a Nexus API key at https://www.nexusmods.com/users/myaccount?tab=api+access (free account).
2. Add it to Rails credentials:
   ```
   EDITOR=nano bin/rails credentials:edit
   nexus_api_key: <your-key>
   ```
3. Bootstrap the collection (one-time):
   ```
   RANGE=1..1000 bin/rails nexus:bootstrap
   ```
4. Schedule `bin/rails nexus:sync` on a 4-hour cron from a maintainer's machine. Sample crontab line is in the `nexus:sync` task description.

## Notes on related open PRs

- File overlap with #112, #113, #116 — whichever lands first, this one will need a rebase. Not a blocker.
- #117 (Rails 8 + Solid Queue) — if that lands, the rake task could be migrated to a `SolidQueue::RecurringJob`. The sync logic lives entirely in `NexusSync`, so that migration is a thin wrapper change rather than a rewrite.

## Deferred / out of scope

- A Nexus mod detail page on Daedalus. For now, "View on Nexus" links out.
- A weekly `nexus:refresh_all` cron — task exists, scheduling deferred.
- A pre-existing nil-crash latent in `find_mods` (`mod.description.match?` on nil description) is not fixed here. NexusMod sets a default of `""` to avoid surfacing it more often, but the underlying bug remains. Worth a follow-up patch.