### PR TITLE
Add kamal to the development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ group :development, :test do
 end
 
 group :development do
+  # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
+  gem "kamal", require: false
+
   # Auditing
   gem "brakeman", "~> 8.0"
   gem "bundler-audit", "~> 0.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt_pbkdf (1.1.2)
     bigdecimal (3.3.1)
     bindex (0.8.1)
     bootsnap (1.24.6)
@@ -106,6 +107,7 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
+    ed25519 (1.4.0)
     erb (6.0.6)
     erubi (1.13.1)
     et-orbi (1.4.1)
@@ -255,6 +257,17 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    kamal (2.12.0)
+      activesupport (>= 7.0)
+      base64 (~> 0.2)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 3.1)
+      ed25519 (~> 1.4)
+      net-ssh (~> 7.3)
+      sshkit (>= 1.23.0, < 2.0)
+      thor (~> 1.3)
+      zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -290,8 +303,13 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
+    net-ssh (7.3.3)
     nio4r (2.7.5)
     nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
@@ -303,6 +321,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     os (1.1.4)
+    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)
@@ -464,6 +483,13 @@ GEM
     sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     tailwindcss-rails (4.6.0)
@@ -518,6 +544,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7)
   importmap-rails
   jbuilder
+  kamal
   propshaft
   pry (~> 0.16)
   pry-rails (~> 0.3.9)


### PR DESCRIPTION
## Summary

Adds `gem "kamal", require: false` to the development group and locks kamal 2.12.0.

**Why:** kamal was only a manually-installed global gem, which silently broke after the Ruby 4.0.6 upgrade (`kamal: command not found` on the first deploy attempt of the new stack — it had to be reinstalled by hand mid-deploy). Bundling it pins the version, survives future Ruby upgrades, and documents the deploy tooling in the Gemfile.

**Placement:** development group rather than stock Rails 8's ungrouped placement, so the production image (built `without development test`) stays lean. Deploys run from a dev machine, never from inside the container.

## Test plan
- [x] `bundle exec kamal version` → 2.12.0
- [x] 335 RSpec examples green
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)